### PR TITLE
Fix `as_document.rmd_tibble`

### DIFF
--- a/R/as_document.R
+++ b/R/as_document.R
@@ -51,7 +51,7 @@ as_document.qmd_collection = function(x, padding = "", collapse = NULL, use_yaml
 
 #' @exportS3Method
 as_document.rmd_tibble = function(x, padding = "", collapse = NULL, use_yaml_opts = TRUE, ...) {
-  as_document(x$ast, padding, collapse, use_yaml_opts = use_yaml_opts, ...)
+  as_document(as_ast(x), padding, collapse, use_yaml_opts = use_yaml_opts, ...)
 }
 
 
@@ -338,5 +338,3 @@ as_document.rmd_inline_code = function(x, ...) {
     "`"
   )
 }
-
-

--- a/R/rmd_fenced_div_wrap.R
+++ b/R/rmd_fenced_div_wrap.R
@@ -196,12 +196,12 @@ rmd_fenced_div_wrap.rmd_tibble = function(x, ..., open = rmd_fenced_div_open(), 
     cli::cli_abort("The following columns must be renamed: {bad_cols}")
   }
 
-  x_ast = as_ast(x)
-  x_ast = rmd_fenced_div_wrap(x_ast, ..., open = open, allow_multiple = allow_multiple)
-
+  ast = rmd_fenced_div_wrap(as_ast(x), ..., open = open, allow_multiple = allow_multiple)
+  x$ast = ast@nodes
+  
   # Recalculate section hierarchy
   x = dplyr::bind_cols(
-    dplyr::bind_rows(rmd_node_sections(x_ast)),  # add new sec_h* columns
+    dplyr::bind_rows(rmd_node_sections(ast)),  # add new sec_h* columns
     dplyr::select(x, -dplyr::starts_with("sec_h")) # drop old sec_h* columns
   )
   class(x) = c("rmd_tibble", class(x))

--- a/R/rmd_insert.R
+++ b/R/rmd_insert.R
@@ -146,11 +146,11 @@ rmd_insert.rmd_tibble = function(x, ..., nodes, location = c("before", "after"),
     cli::cli_abort("The following columns must be renamed: {bad_cols}")
   }
 
-  x_ast = as_ast(x)
-  x_ast = rmd_insert(x_ast, ..., nodes = nodes, location = location, allow_multiple = allow_multiple)
-
+  ast = rmd_insert(as_ast(x), ..., nodes = nodes, location = location, allow_multiple = allow_multiple)
+  x$ast = ast@nodes
+  
   x = dplyr::bind_cols(
-    dplyr::bind_rows(rmd_node_sections(x_ast)),
+    dplyr::bind_rows(rmd_node_sections(ast)),
     dplyr::select(x, -dplyr::starts_with("sec_h"))
   )
   class(x) = c("rmd_tibble", class(x))

--- a/R/rmd_modify.R
+++ b/R/rmd_modify.R
@@ -112,11 +112,12 @@ rmd_modify.rmd_tibble = function(x, .f, ...) {
   if (length(bad_cols) != 0)
     stop("The following columns must be renamed: ", bad_cols, call. = FALSE)
 
-  x$ast = rmd_modify(x$ast, .f, ...)
+  ast = rmd_modify(as_ast(x), .f, ...)
+  x$ast = ast@nodes
 
   # Recalculate section hierarchy
   x = dplyr::bind_cols(
-    dplyr::bind_rows(rmd_node_sections(x$ast)),  # add new sec_h* columns
+    dplyr::bind_rows(rmd_node_sections(ast)),  # add new sec_h* columns
     dplyr::select(x, -dplyr::starts_with("sec_h")) # drop old sec_h* columns
   )
   class(x) = c("rmd_tibble", class(x))

--- a/R/rmd_select.R
+++ b/R/rmd_select.R
@@ -80,7 +80,7 @@ rmd_select.rmd_tibble = function(x, ..., keep_yaml = TRUE) {
   x = x[loc,]
 
   x = dplyr::bind_cols(
-    dplyr::bind_rows(rmd_node_sections(x_ast)),  # add new sec_h* columns
+    dplyr::bind_rows(rmd_node_sections(as_ast(x))),  # add new sec_h* columns
     dplyr::select(x, -dplyr::starts_with("sec_h")) # drop old sec_h* columns
   )
   class(x) = c("rmd_tibble", class(x))

--- a/tests/testthat/test-as_document.R
+++ b/tests/testthat/test-as_document.R
@@ -57,3 +57,10 @@ test_that("raw chunk", {
 })
 
 ## TODO - add checks for other nodes
+
+test_that("as_document.rmd_tibble", {
+  rmd <- parse_rmd(system.file("examples/minimal.Rmd", package = "parsermd"))
+  rmd_tibble <- as_tibble(rmd)
+
+  expect_type(as_document(rmd_tibble), "character")
+})

--- a/tests/testthat/test-rmd_tibble_methods.R
+++ b/tests/testthat/test-rmd_tibble_methods.R
@@ -1,0 +1,96 @@
+test_that("rmd_tibble core methods work correctly", {
+  rmd = parse_rmd(system.file("examples/minimal.Rmd", package = "parsermd"))
+  rmd_tbl = as_tibble(rmd)
+  
+  # Test as_ast roundtrip
+  ast_from_tbl = as_ast(rmd_tbl)
+  expect_s3_class(ast_from_tbl, "rmd_ast")
+  expect_equal(length(ast_from_tbl), length(rmd))
+  
+  # Test as_document
+  doc_from_tbl = as_document(rmd_tbl)
+  doc_from_ast = as_document(rmd)
+  expect_type(doc_from_tbl, "character")
+  expect_equal(doc_from_tbl, doc_from_ast)
+  
+  # Test rmd_node_* methods
+  expect_equal(rmd_node_type(rmd_tbl), rmd_node_type(rmd))
+  expect_equal(rmd_node_label(rmd_tbl), rmd_node_label(rmd))
+  expect_equal(rmd_node_length(rmd_tbl), rmd_node_length(rmd))
+  
+  # Test rmd_select
+  chunks_tbl = rmd_select(rmd_tbl, has_type("rmd_chunk"))
+  chunks_ast = rmd_select(rmd, has_type("rmd_chunk"))
+  expect_s3_class(chunks_tbl, "rmd_tibble")
+  expect_equal(nrow(chunks_tbl), length(chunks_ast))
+  expect_equal(as_document(chunks_tbl), as_document(chunks_ast))
+})
+
+test_that("rmd_tibble insert method works correctly", {
+  rmd = parse_rmd(system.file("examples/minimal.Rmd", package = "parsermd"))
+  rmd_tbl = as_tibble(rmd)
+  
+  # Test rmd_insert 
+  test_node = rmd_markdown("Test content")
+  result_tbl = rmd_insert(rmd_tbl, nodes = test_node, location = "after")
+  result_ast = rmd_insert(rmd, nodes = test_node, location = "after")
+  
+  expect_s3_class(result_tbl, "rmd_tibble")
+  expect_equal(as_document(result_tbl), as_document(result_ast))
+})
+
+test_that("rmd_tibble ast_append and ast_prepend work correctly", {
+  rmd = parse_rmd(system.file("examples/minimal.Rmd", package = "parsermd"))
+  rmd_tbl = as_tibble(rmd)
+  
+  # Test rmd_ast_append
+  test_node = rmd_markdown("Appended content")
+  result_append_tbl = rmd_ast_append(rmd_tbl, test_node)
+  result_append_ast = rmd_ast_append(rmd, test_node)
+  
+  expect_s3_class(result_append_tbl, "rmd_tibble")
+  expect_equal(as_document(result_append_tbl), as_document(result_append_ast))
+  
+  # Test rmd_ast_prepend
+  result_prepend_tbl = rmd_ast_prepend(rmd_tbl, test_node)
+  result_prepend_ast = rmd_ast_prepend(rmd, test_node)
+  
+  expect_s3_class(result_prepend_tbl, "rmd_tibble")
+  expect_equal(as_document(result_prepend_tbl), as_document(result_prepend_ast))
+})
+
+test_that("rmd_tibble chunk options methods work correctly", {
+  rmd = parse_rmd(system.file("examples/minimal.Rmd", package = "parsermd"))
+  rmd_tbl = as_tibble(rmd)
+  
+  # Test rmd_get_options
+  options_tbl = rmd_get_options(rmd_tbl)
+  options_ast = rmd_get_options(rmd)
+  expect_equal(options_tbl, options_ast)
+  
+  # Test rmd_set_options (only on chunks)
+  chunks_tbl = rmd_select(rmd_tbl, has_type("rmd_chunk"))
+  if (nrow(chunks_tbl) > 0) {
+    result = rmd_set_options(chunks_tbl, eval = FALSE)
+    expect_s3_class(result, "rmd_tibble")
+  }
+})
+
+test_that("rmd_tibble modify method works correctly", {
+  rmd = parse_rmd(system.file("examples/minimal.Rmd", package = "parsermd"))
+  rmd_tbl = as_tibble(rmd)
+  
+  # Test rmd_modify - add line numbers to markdown
+  add_line_numbers = function(node) {
+    if (inherits(node, "rmd_markdown")) {
+      node@lines = paste(seq_along(node@lines), node@lines, sep = ". ")
+    }
+    node
+  }
+  
+  result_tbl = rmd_modify(rmd_tbl, add_line_numbers)
+  result_ast = rmd_modify(rmd, add_line_numbers)
+  
+  expect_s3_class(result_tbl, "rmd_tibble")
+  expect_equal(as_document(result_tbl), as_document(result_ast))
+})


### PR DESCRIPTION
With the new update, `as_document.rmd_tibble()` is currently failing because the `ast` column is a normal list with no class:

``` r
library(parsermd)
rmd <- parse_rmd(system.file("examples/minimal.Rmd", package = "parsermd"))
rmd
#> ├── YAML [4 fields]
#> ├── Heading [h1] - Setup
#> │   └── Chunk [r, 1 line] - setup
#> └── Heading [h1] - Content
#>     ├── Heading [h2] - R Markdown
#>     │   ├── Markdown [5 lines]
#>     │   ├── Chunk [r, 1 line] - cars
#>     │   └── Chunk [r, 1 line] - unnamed-chunk-1
#>     └── Heading [h2] - Including Plots
#>         ├── Markdown [1 line]
#>         ├── Chunk [r, 1 line] - pressure
#>         └── Markdown [2 lines]

rmd_tibble <- as_tibble(rmd)

as_document(rmd_tibble)
#> Error in as_document.default(x$ast, padding, collapse, use_yaml_opts = use_yaml_opts, : Unsupported class:list
```

With this change (to match the other `as_document()` methods), calling `as_ast()` on the tibble input, it works:

``` r
library(parsermd)
rmd <- parse_rmd(system.file("examples/minimal.Rmd", package = "parsermd"))
rmd
#> ├── YAML [4 fields]
#> ├── Heading [h1] - Setup
#> │   └── Chunk [r, 1 line] - setup
#> └── Heading [h1] - Content
#>     ├── Heading [h2] - R Markdown
#>     │   ├── Markdown [5 lines]
#>     │   ├── Chunk [r, 1 line] - cars
#>     │   └── Chunk [r, 1 line] - unnamed-chunk-1
#>     └── Heading [h2] - Including Plots
#>         ├── Markdown [1 line]
#>         ├── Chunk [r, 1 line] - pressure
#>         └── Markdown [2 lines]

rmd_tibble <- as_tibble(rmd)

as_document(rmd_tibble)
```

    #>  [1] "---"                                                                                                      
    #>  [2] "title: Minimal"                                                                                           
    #>  [3] "author: Colin Rundel"                                                                                     
    #>  [4] "date: 7/21/2020"                                                                                          
    #>  [5] "output: html_document"                                                                                    
    #>  [6] "---"                                                                                                      
    #>  [7] ""                                                                                                         
    #>  [8] "# Setup"                                                                                                  
    #>  [9] ""                                                                                                         
    #> [10] "```{r setup}"                                                                                             
    #> [11] "#| include: false"                                                                                        
    #> [12] "knitr::opts_chunk$set(echo = TRUE)"                                                                       
    #> [13] "```"                                                                                                      
    #> [14] ""                                                                                                         
    #> [15] "# Content"                                                                                                
    #> [16] ""                                                                                                         
    #> [17] "## R Markdown"                                                                                            
    #> [18] ""                                                                                                         
    #> [19] "This is an R Markdown document. Markdown is a simple formatting syntax for authoring HTML, "              
    #> [20] "PDF, and MS Word documents. For more details on using R Markdown see <http://rmarkdown.rstudio.com>."     
    #> [21] ""                                                                                                         
    #> [22] "When you click the **Knit** button a document will be generated that includes both content as well "      
    #> [23] "as the output of any embedded R code chunks within the document. You can embed an R code chunk like this:"
    #> [24] ""                                                                                                         
    #> [25] ""                                                                                                         
    #> [26] "```{r cars}"                                                                                              
    #> [27] "summary(cars)"                                                                                            
    #> [28] "```"                                                                                                      
    #> [29] ""                                                                                                         
    #> [30] "```{r unnamed-chunk-1}"                                                                                   
    #> [31] "knitr::knit_patterns$get()"                                                                               
    #> [32] "```"                                                                                                      
    #> [33] ""                                                                                                         
    #> [34] "## Including Plots"                                                                                       
    #> [35] ""                                                                                                         
    #> [36] "You can also embed plots, for example:"                                                                   
    #> [37] ""                                                                                                         
    #> [38] ""                                                                                                         
    #> [39] "```{r pressure}"                                                                                          
    #> [40] "#| echo: false"                                                                                           
    #> [41] "plot(pressure)"                                                                                           
    #> [42] "```"                                                                                                      
    #> [43] ""                                                                                                         
    #> [44] "Note that the `echo = FALSE` parameter was added to the code chunk to prevent printing of the R code "    
    #> [45] "that generated the plot."                                                                                 
    #> [46] ""                                                                                                         
    #> [47] ""


<sup>Created on 2025-08-25 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Thanks!